### PR TITLE
switch main entrypoint to server entrypoint

### DIFF
--- a/src/main/java/me/steinborn/krypton/mod/Krypton.java
+++ b/src/main/java/me/steinborn/krypton/mod/Krypton.java
@@ -1,14 +1,14 @@
 package me.steinborn.krypton.mod;
 
-import net.fabricmc.api.ModInitializer;
+import net.fabricmc.api.DedicatedServerModInitializer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-public class Krypton implements ModInitializer {
+public class Krypton implements DedicatedServerModInitializer {
     private static final Logger LOGGER = LogManager.getLogger(Krypton.class);
 
     @Override
-    public void onInitialize() {
+    public void onInitializeServer() {
         LOGGER.info("Krypton is now accelerating your Minecraft server's networking stack \uD83D\uDE80");
     }
 }


### PR DESCRIPTION
Required due to 08ab4a2.
The main entrypoint was changed to be loaded as a server entrypoint, but the entrypoint itself needed to be edited for this to work - otherwise it just crashes when loaded server side.