### PR TITLE
Minor Changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ answer your question.
              growing out of related work I've done. **You have been warned.**
 
 Releases I deem reasonably stable can be found on [GitHub](https://github.com/astei/krypton/releases) and
-[CurseForge](https://www.curseforge.com/minecraft/mc-mods/krypton).  Development builds may be downloaded
+[Modrinth](https://modrinth.com/mod/krypton).  Development builds may be downloaded
 from my [Jenkins server](https://ci.velocitypowered.com/job/krypton/).  They may or may not work.
 
 You can also compile the mod from source in the usual fashion.

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '0.5-SNAPSHOT'
+    id 'fabric-loom' version '0.6-SNAPSHOT'
     id 'maven-publish'
     id "com.github.johnrengelman.shadow" version "6.1.0"
 }

--- a/src/main/java/me/steinborn/krypton/mixin/network/shared/flushconsolidation/ClientConnectionMixin.java
+++ b/src/main/java/me/steinborn/krypton/mixin/network/shared/flushconsolidation/ClientConnectionMixin.java
@@ -57,12 +57,14 @@ public abstract class ClientConnectionMixin implements ConfigurableAutoFlush {
             }
             doSendPacket(packet, callback);
         } else {
-            // In newer versions of Netty, we can avoid wakeups using arbitrary tasks by implementing
-            // AbstractEventExecutor.LazyTask. But we are targeting an older version of Netty and don't
-            // have that luxury. So we'll be a bit clever. If we directly invoke Channel#write, it will
-            // use a WriteTask and that doesn't wake up the event loop. This does have a few preconditions
-            // (we can't be transitioning states, and for simplicity, no callbacks are supported) but if
-            // met this minimizes wakeups when we don't need to immediately do a syscall.
+            /**
+             * In newer versions of Netty, we can avoid wakeups using arbitrary tasks by implementing
+             * AbstractEventExecutor.LazyTask. But we are targeting an older version of Netty and don't
+             * have that luxury. So we'll be a bit clever. If we directly invoke Channel#write, it will
+             * use a WriteTask and that doesn't wake up the event loop. This does have a few preconditions
+             * (we can't be transitioning states, and for simplicity, no callbacks are supported) but if
+             * met this minimizes wakeups when we don't need to immediately do a syscall.
+             */
             if (!newState && callback == null) {
                 ChannelPromise voidPromise = this.channel.voidPromise();
                 if (this.autoFlush.get()) {

--- a/src/main/java/me/steinborn/krypton/mixin/network/shared/pipeline/SplitterHandlerMixin.java
+++ b/src/main/java/me/steinborn/krypton/mixin/network/shared/pipeline/SplitterHandlerMixin.java
@@ -33,8 +33,10 @@ public class SplitterHandlerMixin {
 
         int varintEnd = in.forEachByte(reader);
         if (varintEnd == -1) {
-            // We tried to go beyond the end of the buffer. This is probably a good sign that the
-            // buffer was too short to hold a proper varint.
+            /**
+             * We tried to go beyond the end of the buffer. This is probably a good sign that the
+             * buffer was too short to hold a proper varint.
+             */
             return;
         }
 

--- a/src/main/java/me/steinborn/krypton/mod/shared/KryptonSharedInitializer.java
+++ b/src/main/java/me/steinborn/krypton/mod/shared/KryptonSharedInitializer.java
@@ -10,19 +10,23 @@ public class KryptonSharedInitializer implements ModInitializer {
     private static final Logger LOGGER = LogManager.getLogger(KryptonSharedInitializer.class);
 
     static {
-        // By default, Netty allocates 16MiB arenas for the PooledByteBufAllocator. This is too much
-        // memory for Minecraft, which imposes a maximum packet size of 2MiB! We'll use 4MiB as a more
-        // sane default.
-        //
-        // Note: io.netty.allocator.pageSize << io.netty.allocator.maxOrder is the formula used to
-        // compute the chunk size. We lower maxOrder from its default of 11 to 9. (We also use a null
-        // check, so that the user is free to choose another setting if need be.)
+        /**
+         * By default, Netty allocates 16MiB arenas for the PooledByteBufAllocator. This is too much
+         * memory for Minecraft, which imposes a maximum packet size of 2MiB! We'll use 4MiB as a more
+         * sane default.
+         *
+         * Note: io.netty.allocator.pageSize << io.netty.allocator.maxOrder is the formula used to
+         * compute the chunk size. We lower maxOrder from its default of 11 to 9. (We also use a null
+         * check, so that the user is free to choose another setting if need be.)
+         */
         if (System.getProperty("io.netty.allocator.maxOrder") == null) {
             System.setProperty("io.netty.allocator.maxOrder", "9");
         }
 
-        // Disable the resource leak detector by default as it reduces performance. Allow the user to
-        // override this if desired.
+        /**
+         * Disable the resource leak detector by default as it reduces performance. Allow the user to
+         * override this if desired.
+         */
         if (System.getProperty("io.netty.leakDetection.level") == null) {
             ResourceLeakDetector.setLevel(ResourceLeakDetector.Level.DISABLED);
         }

--- a/src/main/java/me/steinborn/krypton/mod/shared/network/compression/MinecraftCompressEncoder.java
+++ b/src/main/java/me/steinborn/krypton/mod/shared/network/compression/MinecraftCompressEncoder.java
@@ -39,14 +39,16 @@ public class MinecraftCompressEncoder extends MessageToByteEncoder<ByteBuf> {
   @Override
   protected ByteBuf allocateBuffer(ChannelHandlerContext ctx, ByteBuf msg, boolean preferDirect)
       throws Exception {
-    // We allocate bytes to be compressed plus 1 byte. This covers two cases:
-    //
-    // - Compression
-    //    According to https://github.com/ebiggers/libdeflate/blob/master/libdeflate.h#L103,
-    //    if the data compresses well (and we do not have some pathological case) then the maximum
-    //    size the compressed size will ever be is the input size minus one.
-    // - Uncompressed
-    //    This is fairly obvious - we will then have one more than the uncompressed size.
+    /**
+     * We allocate bytes to be compressed plus 1 byte. This covers two cases:
+     *
+     * - Compression
+     *    According to https://github.com/ebiggers/libdeflate/blob/master/libdeflate.h#L103,
+     *    if the data compresses well (and we do not have some pathological case) then the maximum
+     *    size the compressed size will ever be is the input size minus one.
+     * - Uncompressed
+     *    This is fairly obvious - we will then have one more than the uncompressed size.
+     */
     int initialBufferSize = msg.readableBytes() + 1;
     return MoreByteBufUtils.preferredBuffer(ctx.alloc(), compressor, initialBufferSize);
   }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -8,8 +8,9 @@
     "tuxed"
   ],
   "contact": {
-    "website": "https://github.com/astei/krypton",
-    "repo": "https://github.com/astei/krypton"
+    "homepage": "https://github.com/astei/krypton",
+    "sources": "https://github.com/astei/krypton",
+    "issues": "https://github.com/astei/krypton/issues"
   },
   "license": "MIT",
   "icon": "assets/krypton/icon.png",


### PR DESCRIPTION
- Change README curseforge link to modrinth link
- Bump loom version so that ppl using JDK 16 can use (they also need Gradle 7, but they can install that on their end and run `./gradle build` to use the gradle on their computer rather than the gradle wrapper, but the loom version bump is a change that needs to be done in the mod itself)
- Change links in `fabric.mod.json`
- Change some comments to multiline comments to fit in with the rest of the comments in the repo