### PR TITLE
Correct missspelled mixin.

### DIFF
--- a/src/main/resources/krypton.mixins.json
+++ b/src/main/resources/krypton.mixins.json
@@ -17,7 +17,7 @@
     "shared.network.flushconsolidation.EntityTrackerMixin",
     "shared.network.flushconsolidation.ThreadedAnvilChunkStorageMixin",
     "shared.network.microopt.TacsTrackedEntityMixin",
-    "shared.network.misc.PacketByteBufMixin",
+    "shared.network.microopt.PacketByteBufMixin",
     "shared.network.pipeline.LegacyQueryHandlerMixin",
     "shared.network.pipeline.SplitterHandlerMixin",
     "shared.network.pipeline.compression.ClientConnectionMixin",


### PR DESCRIPTION
Fixes a minor issue where a specific mixin has a sub-folder name misspelled. (Closes own issue #42)