### PR TITLE
Fix crash on 22w03a by removing unnecessary shadowed logger

### DIFF
--- a/src/main/java/me/steinborn/krypton/mixin/shared/network/flushconsolidation/ClientConnectionMixin.java
+++ b/src/main/java/me/steinborn/krypton/mixin/shared/network/flushconsolidation/ClientConnectionMixin.java
@@ -7,10 +7,8 @@ import me.steinborn.krypton.mod.shared.network.ConfigurableAutoFlush;
 import net.minecraft.network.ClientConnection;
 import net.minecraft.network.NetworkState;
 import net.minecraft.network.Packet;
-import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
 import org.objectweb.asm.Opcodes;
-import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -30,8 +28,6 @@ public abstract class ClientConnectionMixin implements ConfigurableAutoFlush {
     private AtomicBoolean autoFlush;
 
     @Shadow public abstract void setState(NetworkState state);
-
-    @Shadow @Final private static Logger LOGGER;
 
     @Inject(method = "<init>", at = @At("RETURN"))
     private void initAddedFields(CallbackInfo ci) {


### PR DESCRIPTION
This shadowed logger causes a crash on 22w03a due to the MC logger having been switched. This logger wasn't even used, so instead of fixing/changing, I just removed it entirely. Game works fine with this change, but without this change, it crashes with mixin errors.