### PR TITLE
Chunk loading order changes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '0.10-SNAPSHOT'
+    id 'fabric-loom' version '0.11-SNAPSHOT'
     id 'maven-publish'
 }
 
@@ -69,6 +69,26 @@ publishing {
     publications {
         mavenJava(MavenPublication) {
             from components.java
+        }
+    }
+}
+
+tasks.getByName("configureClientLaunch") {
+    doFirst {
+        loom {
+            runs {
+                all {
+                    property("fabric.development=true")
+                    property("mixin.hotSwap")
+                    // vmArg("-javaagent:${dependencies.module(group = "net.fabricmc", name = "sponge-mixin")}")
+                    def mixinJarFile = configurations.compileClasspath.files {
+                        it.group == "net.fabricmc" && it.name == "sponge-mixin"
+                    }.find { true }
+                    vmArg("-javaagent:$mixinJarFile")
+
+                    ideConfigGenerated = true
+                }
+            }
         }
     }
 }

--- a/src/main/java/me/steinborn/krypton/mixin/shared/bugfix/ChunkTicketManagerMixin.java
+++ b/src/main/java/me/steinborn/krypton/mixin/shared/bugfix/ChunkTicketManagerMixin.java
@@ -1,0 +1,26 @@
+package me.steinborn.krypton.mixin.shared.bugfix;
+
+
+import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
+import it.unimi.dsi.fastutil.objects.ObjectSet;
+import it.unimi.dsi.fastutil.objects.ObjectSets;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.world.ChunkTicketManager;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+
+@Mixin(ChunkTicketManager.class)
+public class ChunkTicketManagerMixin {
+
+    @Redirect(method = "handleChunkLeave(Lnet/minecraft/util/math/ChunkSectionPos;Lnet/minecraft/server/network/ServerPlayerEntity;)V",
+              at = @At(value = "INVOKE", target = "Lit/unimi/dsi/fastutil/longs/Long2ObjectMap;get(J)Ljava/lang/Object;"))
+    public Object handleChunkLeave(Long2ObjectMap<ObjectSet<ServerPlayerEntity>> instance, long l) {
+        ObjectSet<ServerPlayerEntity> objectSet = instance.get(l);
+        if (objectSet == null)
+            return ObjectSets.emptySet();
+        else
+            return objectSet;
+    }
+}

--- a/src/main/java/me/steinborn/krypton/mixin/shared/network/flushconsolidation/ThreadedAnvilChunkStorageMixin.java
+++ b/src/main/java/me/steinborn/krypton/mixin/shared/network/flushconsolidation/ThreadedAnvilChunkStorageMixin.java
@@ -1,21 +1,18 @@
 package me.steinborn.krypton.mixin.shared.network.flushconsolidation;
 
+
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import me.steinborn.krypton.mod.shared.network.util.AutoFlushUtil;
-import net.minecraft.network.Packet;
 import net.minecraft.network.packet.s2c.play.ChunkDataS2CPacket;
-import net.minecraft.server.network.DebugInfoSender;
 import net.minecraft.server.network.ServerPlayerEntity;
-import net.minecraft.server.world.ChunkHolder;
 import net.minecraft.server.world.PlayerChunkWatchingManager;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.server.world.ThreadedAnvilChunkStorage;
 import net.minecraft.util.math.ChunkPos;
 import net.minecraft.util.math.ChunkSectionPos;
-import net.minecraft.util.math.MathHelper;
-import net.minecraft.world.chunk.WorldChunk;
 import org.apache.commons.lang3.mutable.MutableObject;
-import org.jetbrains.annotations.Nullable;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
@@ -24,31 +21,75 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import java.util.HashSet;
-import java.util.Set;
 
 /**
- * Mixes into various methods in {@code ThreadedAnvilChunkStorage} to utilize flush consolidation for sending chunks
- * all at once to the client. Helpful for heavy server activity or flying very quickly.
+ * Mixes into various methods in {@code ThreadedAnvilChunkStorage} to utilize flush consolidation for sending chunks all at once to the
+ * client. Helpful for heavy server activity or flying very quickly.
+ * <p>
+ * Note for anyone attempting to modify this class in the future: for some reason, mojang includes both the chunk loading & chunk unloading
+ * packets in the <i>same</i> method. This is why chunks must <i>always</i> be sent to the player when they leave an area.
  */
 @Mixin(ThreadedAnvilChunkStorage.class)
 public abstract class ThreadedAnvilChunkStorageMixin {
-    @Shadow @Final private Int2ObjectMap<ThreadedAnvilChunkStorage.EntityTracker> entityTrackers;
-    @Shadow @Final private PlayerChunkWatchingManager playerChunkWatchingManager;
-    @Shadow @Final private ServerWorld world;
-    @Shadow @Final private ThreadedAnvilChunkStorage.TicketManager ticketManager;
-    @Shadow private int watchDistance;
-
-    @Shadow protected abstract boolean doesNotGenerateChunks(ServerPlayerEntity player);
-
-    @Shadow protected abstract ChunkSectionPos updateWatchedSection(ServerPlayerEntity serverPlayerEntity);
-
+    private static final Logger LOGGER = LogManager.getLogger(ThreadedAnvilChunkStorageMixin.class);
+    
+    @Shadow
+    @Final
+    private Int2ObjectMap<ThreadedAnvilChunkStorage.EntityTracker> entityTrackers;
+    
+    @Shadow
+    @Final
+    private PlayerChunkWatchingManager playerChunkWatchingManager;
+    
+    @Shadow
+    @Final
+    private ServerWorld world;
+    
+    @Shadow
+    @Final
+    private ThreadedAnvilChunkStorage.TicketManager ticketManager;
+    
+    @Shadow
+    private int watchDistance;
+    
     @Shadow
     public static boolean isWithinDistance(int x1, int y1, int x2, int y2, int maxDistance) {
         // PAIL: isWithinEuclideanDistance(x1, y1, x2, y2, maxDistance)
         throw new AssertionError("pedantic");
     }
-
+    
+    /**
+     * This is run on login. This method is overwritten to avoid sending duplicate chunks (which mc does by default)
+     *
+     * @author solonovamax
+     */
+    @Overwrite
+    public void handlePlayerAddedOrRemoved(ServerPlayerEntity player, boolean added) {
+        boolean isWatchingWorld = this.playerChunkWatchingManager.isWatchInactive(player);
+        boolean doesChunkGen = !this.doesNotGenerateChunks(player);
+        
+        int chunkPosX = ChunkSectionPos.getSectionCoord(player.getBlockX());
+        int chunkPosZ = ChunkSectionPos.getSectionCoord(player.getBlockZ());
+        
+        if (added) {
+            this.playerChunkWatchingManager.add(ChunkPos.toLong(chunkPosX, chunkPosZ), player, isWatchingWorld);
+            this.updateWatchedSection(player);
+            if (!isWatchingWorld) {
+                this.ticketManager.handleChunkEnter(ChunkSectionPos.from(player), player);
+            }
+        } else {
+            ChunkSectionPos chunkSectionPos = player.getWatchedSection();
+            this.playerChunkWatchingManager.remove(chunkSectionPos.toChunkPos().toLong(), player);
+            
+            if (doesChunkGen) {
+                this.ticketManager.handleChunkLeave(chunkSectionPos, player);
+            }
+        }
+        
+        // Send chunk watch packets even if the player has been removed, as this also send chunk unload packets
+        sendSpiralChunkWatchPackets(player);
+    }
+    
     /**
      * @author Andrew Steinborn
      * @reason Add support for flush consolidation
@@ -64,60 +105,119 @@ public abstract class ThreadedAnvilChunkStorageMixin {
                 entityTracker.updateTrackedStatus(player);
             }
         }
-
+        
         ChunkSectionPos oldPos = player.getWatchedSection();
         ChunkSectionPos newPos = ChunkSectionPos.from(player);
         boolean isWatchingWorld = this.playerChunkWatchingManager.isWatchDisabled(player);
         boolean noChunkGen = this.doesNotGenerateChunks(player);
         boolean movedSections = !oldPos.equals(newPos);
-
+        
+        
         if (movedSections || isWatchingWorld != noChunkGen) {
             this.updateWatchedSection(player);
-
+            
             if (!isWatchingWorld) {
                 this.ticketManager.handleChunkLeave(oldPos, player);
             }
-
+            
             if (!noChunkGen) {
                 this.ticketManager.handleChunkEnter(newPos, player);
             }
-
+            
             if (!isWatchingWorld && noChunkGen) {
                 this.playerChunkWatchingManager.disableWatch(player);
             }
-
+            
             if (isWatchingWorld && !noChunkGen) {
                 this.playerChunkWatchingManager.enableWatch(player);
             }
-
+            
             long oldChunkPos = ChunkPos.toLong(oldPos.getX(), oldPos.getZ());
             long newChunkPos = ChunkPos.toLong(newPos.getX(), newPos.getZ());
             this.playerChunkWatchingManager.movePlayer(oldChunkPos, newChunkPos, player);
-
-            // If the player is in the same world as this tracker, we should send them chunks.
-            if (this.world == player.world) {
-                this.sendChunks(oldPos, player);
-            }
+        }
+        
+        // The player *always* needs to be send chunks, as for some reason both chunk loading & unloading packets are handled
+        // by the same method (why mojang)
+        if (player.world == this.world) {
+            this.sendChunkWatchPackets(oldPos, player);
         }
     }
-
-    private void sendChunks(ChunkSectionPos oldPos, ServerPlayerEntity player) {
+    
+    @Inject(method = "tickEntityMovement", at = @At("HEAD"))
+    public void disableAutoFlushForEntityTracking(CallbackInfo info) {
+        for (ServerPlayerEntity player : world.getPlayers()) {
+            AutoFlushUtil.setAutoFlush(player, false);
+        }
+    }
+    
+    @Inject(method = "tickEntityMovement", at = @At("RETURN"))
+    public void enableAutoFlushForEntityTracking(CallbackInfo info) {
+        for (ServerPlayerEntity player : world.getPlayers()) {
+            AutoFlushUtil.setAutoFlush(player, true);
+        }
+    }
+    
+    @Shadow
+    public abstract void sendWatchPackets(ServerPlayerEntity player, ChunkPos pos, MutableObject<ChunkDataS2CPacket> mutableObject,
+                                          boolean withinMaxWatchDistance, boolean withinViewDistance);
+    
+    @Shadow
+    protected abstract boolean doesNotGenerateChunks(ServerPlayerEntity player);
+    
+    @Shadow
+    protected abstract ChunkSectionPos updateWatchedSection(ServerPlayerEntity serverPlayerEntity);
+    
+    /**
+     * Sends watch packets to the client in a spiral for a player which has *no* chunks loaded in the area.
+     *
+     * @author solonovamax
+     */
+    private void sendSpiralChunkWatchPackets(ServerPlayerEntity player) {
+        int chunkPosX = ChunkSectionPos.getSectionCoord(player.getBlockX());
+        int chunkPosZ = ChunkSectionPos.getSectionCoord(player.getBlockZ());
+        
+        int x = 0, z = 0, dx = 0, dz = -1;
+        int t = this.watchDistance * 2;
+        int maxI = t * t * 2;
+        for (int i = 0; i < maxI; i++) {
+            if ((-this.watchDistance <= x) && (x <= this.watchDistance) && (-this.watchDistance <= z) && (z <= this.watchDistance)) {
+                LOGGER.info("Sending chunk at pos [{}, {}]", chunkPosX + x, chunkPosZ + z);
+                
+                this.sendWatchPackets(player,
+                                      new ChunkPos(chunkPosX + x, chunkPosZ + z),
+                                      new MutableObject<>(), false, true);
+            }
+            if ((x == z) || ((x < 0) && (x == -z)) || ((x > 0) && (x == 1 - z))) {
+                t = dx;
+                dx = -dz;
+                dz = t;
+            }
+            x += dx;
+            z += dz;
+        }
+    }
+    
+    private void sendChunkWatchPackets(ChunkSectionPos oldPos, ServerPlayerEntity player) {
         AutoFlushUtil.setAutoFlush(player, false);
-
+        
         try {
             int oldChunkX = oldPos.getSectionX();
             int oldChunkZ = oldPos.getSectionZ();
-
-            int newChunkX = MathHelper.floor(player.getX()) >> 4;
-            int newChunkZ = MathHelper.floor(player.getZ()) >> 4;
-
+            
+            int newChunkX = ChunkSectionPos.getSectionCoord(player.getBlockX());
+            int newChunkZ = ChunkSectionPos.getSectionCoord(player.getBlockZ());
+            
             // TODO: Track chunks the server has sent the player
             if (Math.abs(oldChunkX - newChunkX) <= this.watchDistance * 2 && Math.abs(oldChunkZ - newChunkZ) <= this.watchDistance * 2) {
                 int minSendChunkX = Math.min(newChunkX, oldChunkX) - this.watchDistance - 1;
                 int minSendChunkZ = Math.min(newChunkZ, oldChunkZ) - this.watchDistance - 1;
                 int maxSendChunkX = Math.max(newChunkX, oldChunkX) + this.watchDistance + 1;
                 int maxSendChunkZ = Math.max(newChunkZ, oldChunkZ) + this.watchDistance + 1;
-
+                
+                // We're sending *all* chunks in the range of where the player was, to where the player currently is.
+                // This is because the #sendWatchPackets method will also unload chunks.
+                // For chunks outside of the view distance, it does nothing.
                 for (int curX = minSendChunkX; curX <= maxSendChunkX; ++curX) {
                     for (int curZ = minSendChunkZ; curZ <= maxSendChunkZ; ++curZ) {
                         ChunkPos chunkPos = new ChunkPos(curX, curZ);
@@ -126,46 +226,25 @@ public abstract class ThreadedAnvilChunkStorageMixin {
                         this.sendWatchPackets(player, chunkPos, new MutableObject<>(), inOld, inNew);
                     }
                 }
-            } else {
-                int x = 0, z = 0, dx = 0, dz = -1;
-                int t = this.watchDistance * 2;
-                int maxI = t * t * 2;
-                for(int i = 0; i < maxI; i++){
-                    if ((-this.watchDistance <= x) && (x <= this.watchDistance) && (-this.watchDistance <= z) && (z <= this.watchDistance)){
-                        this.sendWatchPackets(player,
-                            new ChunkPos(newChunkX + x, newChunkZ + z),
-                            new MutableObject<>(), false, true
-                        );
+            } else { // If the player is not near the old chunks, send all new chunks & unload old chunks
+                
+                // Unload previous chunks
+                // Chunk unload packets are very light, so we can just do it like this
+                for (int curX = oldChunkX - watchDistance - 1; curX <= oldChunkX + watchDistance + 1; ++curX) {
+                    for (int curZ = oldChunkZ - watchDistance - 1; curZ <= oldChunkZ + watchDistance + 1; ++curZ) {
+                        ChunkPos chunkPos = new ChunkPos(curX, curZ);
+                        
+                        this.sendWatchPackets(player, chunkPos, new MutableObject<>(), false, true);
                     }
-                    if ((x == z) || ((x < 0) && (x == -z)) || ((x > 0) && (x == 1-z))) {
-                        t = dx;
-                        dx = -dz;
-                        dz = t;
-                    }
-                    x += dx;
-                    z += dz;
                 }
+                
+                // Send new chunks
+                sendSpiralChunkWatchPackets(player);
+                
             }
         } finally {
             AutoFlushUtil.setAutoFlush(player, true);
         }
     }
-
-    @Shadow
-    protected abstract void sendWatchPackets(ServerPlayerEntity player, ChunkPos pos, MutableObject<ChunkDataS2CPacket> mutableObject, boolean withinMaxWatchDistance, boolean withinViewDistance);
-
-    @Inject(method = "tickEntityMovement", at = @At("HEAD"))
-    public void disableAutoFlushForEntityTracking(CallbackInfo info) {
-        for (ServerPlayerEntity player : world.getPlayers()) {
-            AutoFlushUtil.setAutoFlush(player, false);
-        }
-    }
-
-    @Inject(method = "tickEntityMovement", at = @At("RETURN"))
-    public void enableAutoFlushForEntityTracking(CallbackInfo info) {
-        for (ServerPlayerEntity player : world.getPlayers()) {
-            AutoFlushUtil.setAutoFlush(player, true);
-        }
-    }
-
+    
 }

--- a/src/main/java/me/steinborn/krypton/mixin/shared/network/flushconsolidation/ThreadedAnvilChunkStorageMixin.java
+++ b/src/main/java/me/steinborn/krypton/mixin/shared/network/flushconsolidation/ThreadedAnvilChunkStorageMixin.java
@@ -11,8 +11,6 @@ import net.minecraft.server.world.ThreadedAnvilChunkStorage;
 import net.minecraft.util.math.ChunkPos;
 import net.minecraft.util.math.ChunkSectionPos;
 import org.apache.commons.lang3.mutable.MutableObject;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
@@ -31,8 +29,6 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
  */
 @Mixin(ThreadedAnvilChunkStorage.class)
 public abstract class ThreadedAnvilChunkStorageMixin {
-    private static final Logger LOGGER = LogManager.getLogger(ThreadedAnvilChunkStorageMixin.class);
-    
     @Shadow
     @Final
     private Int2ObjectMap<ThreadedAnvilChunkStorage.EntityTracker> entityTrackers;
@@ -159,10 +155,9 @@ public abstract class ThreadedAnvilChunkStorageMixin {
     }
     
     /**
-     * 
-     * @param player The player
-     * @param pos The position of the chunk to send
-     * @param mutableObject A new mutable object
+     * @param player                The player
+     * @param pos                   The position of the chunk to send
+     * @param mutableObject         A new mutable object
      * @param oldWithinViewDistance If the chunk was previously within the player's view distance
      * @param newWithinViewDistance If the chunk is now within the player's view distance
      */
@@ -190,8 +185,6 @@ public abstract class ThreadedAnvilChunkStorageMixin {
         int maxI = t * t * 2;
         for (int i = 0; i < maxI; i++) {
             if ((-this.watchDistance <= x) && (x <= this.watchDistance) && (-this.watchDistance <= z) && (z <= this.watchDistance)) {
-                LOGGER.info("Sending chunk at pos [{}, {}]", chunkPosX + x, chunkPosZ + z);
-                
                 this.sendWatchPackets(player,
                                       new ChunkPos(chunkPosX + x, chunkPosZ + z),
                                       new MutableObject<>(), false, true);

--- a/src/main/java/me/steinborn/krypton/mixin/shared/network/flushconsolidation/ThreadedAnvilChunkStorageMixin.java
+++ b/src/main/java/me/steinborn/krypton/mixin/shared/network/flushconsolidation/ThreadedAnvilChunkStorageMixin.java
@@ -158,9 +158,17 @@ public abstract class ThreadedAnvilChunkStorageMixin {
         }
     }
     
+    /**
+     * 
+     * @param player The player
+     * @param pos The position of the chunk to send
+     * @param mutableObject A new mutable object
+     * @param oldWithinViewDistance If the chunk was previously within the player's view distance
+     * @param newWithinViewDistance If the chunk is now within the player's view distance
+     */
     @Shadow
     public abstract void sendWatchPackets(ServerPlayerEntity player, ChunkPos pos, MutableObject<ChunkDataS2CPacket> mutableObject,
-                                          boolean withinMaxWatchDistance, boolean withinViewDistance);
+                                          boolean oldWithinViewDistance, boolean newWithinViewDistance);
     
     @Shadow
     protected abstract boolean doesNotGenerateChunks(ServerPlayerEntity player);
@@ -234,7 +242,7 @@ public abstract class ThreadedAnvilChunkStorageMixin {
                     for (int curZ = oldChunkZ - watchDistance - 1; curZ <= oldChunkZ + watchDistance + 1; ++curZ) {
                         ChunkPos chunkPos = new ChunkPos(curX, curZ);
                         
-                        this.sendWatchPackets(player, chunkPos, new MutableObject<>(), false, true);
+                        this.sendWatchPackets(player, chunkPos, new MutableObject<>(), true, false);
                     }
                 }
                 

--- a/src/main/java/me/steinborn/krypton/mixin/shared/network/flushconsolidation/ThreadedAnvilChunkStorageMixin.java
+++ b/src/main/java/me/steinborn/krypton/mixin/shared/network/flushconsolidation/ThreadedAnvilChunkStorageMixin.java
@@ -3,6 +3,7 @@ package me.steinborn.krypton.mixin.shared.network.flushconsolidation;
 
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import me.steinborn.krypton.mod.shared.network.util.AutoFlushUtil;
+import me.steinborn.krypton.mod.shared.player.KryptonServerPlayerEntity;
 import net.minecraft.network.packet.s2c.play.ChunkDataS2CPacket;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.PlayerChunkWatchingManager;
@@ -57,6 +58,7 @@ public abstract class ThreadedAnvilChunkStorageMixin {
     /**
      * This is run on login. This method is overwritten to avoid sending duplicate chunks (which mc does by default)
      *
+     * @reason optimize sending chunks
      * @author solonovamax
      */
     @Overwrite
@@ -67,28 +69,36 @@ public abstract class ThreadedAnvilChunkStorageMixin {
         int chunkPosX = ChunkSectionPos.getSectionCoord(player.getBlockX());
         int chunkPosZ = ChunkSectionPos.getSectionCoord(player.getBlockZ());
 
-        if (added) {
-            this.playerChunkWatchingManager.add(ChunkPos.toLong(chunkPosX, chunkPosZ), player, isWatchingWorld);
-            this.updateWatchedSection(player);
-            if (!isWatchingWorld) {
-                this.ticketManager.handleChunkEnter(ChunkSectionPos.from(player), player);
-            }
-        } else {
-            ChunkSectionPos chunkSectionPos = player.getWatchedSection();
-            this.playerChunkWatchingManager.remove(chunkSectionPos.toChunkPos().toLong(), player);
+        AutoFlushUtil.setAutoFlush(player, false);
+        try {
+            if (added) {
+                this.playerChunkWatchingManager.add(ChunkPos.toLong(chunkPosX, chunkPosZ), player, isWatchingWorld);
+                this.updateWatchedSection(player);
+                if (!isWatchingWorld) {
+                    this.ticketManager.handleChunkEnter(ChunkSectionPos.from(player), player);
+                }
 
-            if (doesChunkGen) {
-                this.ticketManager.handleChunkLeave(chunkSectionPos, player);
+                // Send spiral watch packets if added
+                sendSpiralChunkWatchPackets(player);
+            } else {
+                ChunkSectionPos chunkSectionPos = player.getWatchedSection();
+                this.playerChunkWatchingManager.remove(chunkSectionPos.toChunkPos().toLong(), player);
+
+                if (doesChunkGen) {
+                    this.ticketManager.handleChunkLeave(chunkSectionPos, player);
+                }
+
+                // Loop through & unload chunks if removed
+                unloadChunks(player, chunkPosX, chunkPosZ, watchDistance);
             }
+        } finally {
+            AutoFlushUtil.setAutoFlush(player, true);
         }
-
-        // Send chunk watch packets even if the player has been removed, as this also send chunk unload packets
-        sendSpiralChunkWatchPackets(player);
     }
 
     /**
      * @author Andrew Steinborn
-     * @reason Add support for flush consolidation
+     * @reason Add support for flush consolidation & optimize sending chunks
      */
     @Overwrite
     public void updatePosition(ServerPlayerEntity player) {
@@ -134,9 +144,8 @@ public abstract class ThreadedAnvilChunkStorageMixin {
 
         // The player *always* needs to be send chunks, as for some reason both chunk loading & unloading packets are handled
         // by the same method (why mojang)
-        if (player.world == this.world) {
+        if (player.world == this.world)
             this.sendChunkWatchPackets(oldPos, player);
-        }
     }
 
     @Inject(method = "tickEntityMovement", at = @At("HEAD"))
@@ -170,21 +179,87 @@ public abstract class ThreadedAnvilChunkStorageMixin {
     @Shadow
     protected abstract ChunkSectionPos updateWatchedSection(ServerPlayerEntity serverPlayerEntity);
 
+    private void sendChunkWatchPackets(ChunkSectionPos oldPos, ServerPlayerEntity player) {
+        AutoFlushUtil.setAutoFlush(player, false);
+        try {
+            int oldChunkX = oldPos.getSectionX();
+            int oldChunkZ = oldPos.getSectionZ();
+
+            int newChunkX = ChunkSectionPos.getSectionCoord(player.getBlockX());
+            int newChunkZ = ChunkSectionPos.getSectionCoord(player.getBlockZ());
+
+            int playerViewDistance = getPlayerViewDistance(player); // +1 for buffer
+
+            if (reloadAllChunks(player)) { // Player updated view distance, unload chunks & resend (only unload chunks not visible)
+                //noinspection InstanceofIncompatibleInterface
+                if (player instanceof KryptonServerPlayerEntity kryptonPlayer)
+                    kryptonPlayer.setUpdatedViewDistance(true);
+
+                for (int curX = newChunkX - watchDistance - 1; curX <= newChunkX + watchDistance + 1; ++curX) {
+                    for (int curZ = newChunkZ - watchDistance - 1; curZ <= newChunkZ + watchDistance + 1; ++curZ) {
+                        ChunkPos chunkPos = new ChunkPos(curX, curZ);
+                        boolean inNew = isWithinDistance(curX, curZ, newChunkX, newChunkZ, playerViewDistance);
+
+                        this.sendWatchPackets(player, chunkPos, new MutableObject<>(), true, inNew);
+                    }
+                }
+
+                // Send new chunks
+                sendSpiralChunkWatchPackets(player);
+            } else if (Math.abs(oldChunkX - newChunkX) > playerViewDistance * 2 ||
+                       Math.abs(oldChunkZ - newChunkZ) > playerViewDistance * 2) {
+                // If the player is not near the old chunks, send all new chunks & unload old chunks
+
+                // Unload previous chunks
+                // Chunk unload packets are very light, so we can just do it like this
+                unloadChunks(player, oldChunkX, oldChunkZ, watchDistance);
+
+                // Send new chunks
+                sendSpiralChunkWatchPackets(player);
+            } else {
+                int minSendChunkX = Math.min(newChunkX, oldChunkX) - playerViewDistance - 1;
+                int minSendChunkZ = Math.min(newChunkZ, oldChunkZ) - playerViewDistance - 1;
+                int maxSendChunkX = Math.max(newChunkX, oldChunkX) + playerViewDistance + 1;
+                int maxSendChunkZ = Math.max(newChunkZ, oldChunkZ) + playerViewDistance + 1;
+
+                // We're sending *all* chunks in the range of where the player was, to where the player currently is.
+                // This is because the #sendWatchPackets method will also unload chunks.
+                // For chunks outside of the view distance, it does nothing.
+                for (int curX = minSendChunkX; curX <= maxSendChunkX; ++curX) {
+                    for (int curZ = minSendChunkZ; curZ <= maxSendChunkZ; ++curZ) {
+                        ChunkPos chunkPos = new ChunkPos(curX, curZ);
+                        boolean inOld = isWithinDistance(curX, curZ, oldChunkX, oldChunkZ, playerViewDistance);
+                        boolean inNew = isWithinDistance(curX, curZ, newChunkX, newChunkZ, playerViewDistance);
+                        this.sendWatchPackets(player, chunkPos, new MutableObject<>(), inOld, inNew);
+                    }
+                }
+            }
+        } finally {
+            AutoFlushUtil.setAutoFlush(player, true);
+        }
+    }
+
     /**
-     * Sends watch packets to the client in a spiral for a player which has *no* chunks loaded in the area.
+     * Sends watch packets to the client in a spiral for a player, which has *no* chunks loaded in the area.
      */
     private void sendSpiralChunkWatchPackets(ServerPlayerEntity player) {
         int chunkPosX = ChunkSectionPos.getSectionCoord(player.getBlockX());
         int chunkPosZ = ChunkSectionPos.getSectionCoord(player.getBlockZ());
 
+
+        // + 1 because mc adds 1 when it sends chunks
+        int playerViewDistance = getPlayerViewDistance(player) + 1;
+
         int x = 0, z = 0, dx = 0, dz = -1;
-        int t = this.watchDistance * 2;
+        int t = playerViewDistance * 2;
         int maxI = t * t * 2;
         for (int i = 0; i < maxI; i++) {
-            if ((-this.watchDistance <= x) && (x <= this.watchDistance) && (-this.watchDistance <= z) && (z <= this.watchDistance)) {
+            if ((-playerViewDistance <= x) && (x <= playerViewDistance) && (-playerViewDistance <= z) && (z <= playerViewDistance)) {
+                boolean inNew = isWithinDistance(chunkPosX, chunkPosZ, chunkPosX + x, chunkPosZ + z, playerViewDistance);
+
                 this.sendWatchPackets(player,
                                       new ChunkPos(chunkPosX + x, chunkPosZ + z),
-                                      new MutableObject<>(), false, true);
+                                      new MutableObject<>(), false, inNew);
             }
             if ((x == z) || ((x < 0) && (x == -z)) || ((x > 0) && (x == 1 - z))) {
                 t = dx;
@@ -196,52 +271,30 @@ public abstract class ThreadedAnvilChunkStorageMixin {
         }
     }
 
-    private void sendChunkWatchPackets(ChunkSectionPos oldPos, ServerPlayerEntity player) {
-        AutoFlushUtil.setAutoFlush(player, false);
+    private void unloadChunks(ServerPlayerEntity player, int chunkPosX, int chunkPosZ, int distance) {
+        for (int curX = chunkPosX - distance - 1; curX <= chunkPosX + distance + 1; ++curX) {
+            for (int curZ = chunkPosZ - distance - 1; curZ <= chunkPosZ + distance + 1; ++curZ) {
+                ChunkPos chunkPos = new ChunkPos(curX, curZ);
 
-        try {
-            int oldChunkX = oldPos.getSectionX();
-            int oldChunkZ = oldPos.getSectionZ();
-
-            int newChunkX = ChunkSectionPos.getSectionCoord(player.getBlockX());
-            int newChunkZ = ChunkSectionPos.getSectionCoord(player.getBlockZ());
-
-            // TODO: Track chunks the server has sent the player
-            if (Math.abs(oldChunkX - newChunkX) <= this.watchDistance * 2 && Math.abs(oldChunkZ - newChunkZ) <= this.watchDistance * 2) {
-                int minSendChunkX = Math.min(newChunkX, oldChunkX) - this.watchDistance - 1;
-                int minSendChunkZ = Math.min(newChunkZ, oldChunkZ) - this.watchDistance - 1;
-                int maxSendChunkX = Math.max(newChunkX, oldChunkX) + this.watchDistance + 1;
-                int maxSendChunkZ = Math.max(newChunkZ, oldChunkZ) + this.watchDistance + 1;
-
-                // We're sending *all* chunks in the range of where the player was, to where the player currently is.
-                // This is because the #sendWatchPackets method will also unload chunks.
-                // For chunks outside of the view distance, it does nothing.
-                for (int curX = minSendChunkX; curX <= maxSendChunkX; ++curX) {
-                    for (int curZ = minSendChunkZ; curZ <= maxSendChunkZ; ++curZ) {
-                        ChunkPos chunkPos = new ChunkPos(curX, curZ);
-                        boolean inOld = isWithinDistance(curX, curZ, oldChunkX, oldChunkZ, this.watchDistance);
-                        boolean inNew = isWithinDistance(curX, curZ, newChunkX, newChunkZ, this.watchDistance);
-                        this.sendWatchPackets(player, chunkPos, new MutableObject<>(), inOld, inNew);
-                    }
-                }
-            } else { // If the player is not near the old chunks, send all new chunks & unload old chunks
-
-                // Unload previous chunks
-                // Chunk unload packets are very light, so we can just do it like this
-                for (int curX = oldChunkX - watchDistance - 1; curX <= oldChunkX + watchDistance + 1; ++curX) {
-                    for (int curZ = oldChunkZ - watchDistance - 1; curZ <= oldChunkZ + watchDistance + 1; ++curZ) {
-                        ChunkPos chunkPos = new ChunkPos(curX, curZ);
-
-                        this.sendWatchPackets(player, chunkPos, new MutableObject<>(), true, false);
-                    }
-                }
-
-                // Send new chunks
-                sendSpiralChunkWatchPackets(player);
-
+                this.sendWatchPackets(player, chunkPos, new MutableObject<>(), true, false);
             }
-        } finally {
-            AutoFlushUtil.setAutoFlush(player, true);
         }
+    }
+
+    private int getPlayerViewDistance(ServerPlayerEntity playerEntity) {
+        //noinspection InstanceofIncompatibleInterface
+        return playerEntity instanceof KryptonServerPlayerEntity kryptonPlayerEntity
+               ? kryptonPlayerEntity.getPlayerViewDistance() != -1
+                 // if -1, the view distance hasn't been set
+                 // We *actually* need to send view distance + 1, because mc doesn't render chunks adjacent to unloaded ones
+                 ? Math.min(this.watchDistance,
+                            kryptonPlayerEntity.getPlayerViewDistance() +
+                            1)
+                 : this.watchDistance : this.watchDistance;
+    }
+
+    private boolean reloadAllChunks(ServerPlayerEntity playerEntity) {
+        //noinspection InstanceofIncompatibleInterface
+        return playerEntity instanceof KryptonServerPlayerEntity kryptonPlayerEntity && kryptonPlayerEntity.isUpdatedViewDistance();
     }
 }

--- a/src/main/java/me/steinborn/krypton/mixin/shared/player/ServerPlayerEntityMixin.java
+++ b/src/main/java/me/steinborn/krypton/mixin/shared/player/ServerPlayerEntityMixin.java
@@ -18,26 +18,26 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public class ServerPlayerEntityMixin implements KryptonServerPlayerEntity {
     @Unique
     private int playerViewDistance = -1;
-    
+
     @Unique
     private boolean updatedViewDistance = false;
-    
+
     @Inject(method = "setClientSettings", at = @At("HEAD"))
     public void setClientSettings(ClientSettingsC2SPacket packet, CallbackInfo ci) {
         updatedViewDistance = (playerViewDistance != packet.viewDistance());
         playerViewDistance = packet.viewDistance();
     }
-    
+
     @Override
     public boolean isUpdatedViewDistance() {
         return updatedViewDistance;
     }
-    
+
     @Override
     public void setUpdatedViewDistance(boolean updatedViewDistance) {
         this.updatedViewDistance = updatedViewDistance;
     }
-    
+
     @Override
     public int getPlayerViewDistance() {
         return playerViewDistance;

--- a/src/main/java/me/steinborn/krypton/mixin/shared/player/ServerPlayerEntityMixin.java
+++ b/src/main/java/me/steinborn/krypton/mixin/shared/player/ServerPlayerEntityMixin.java
@@ -1,0 +1,45 @@
+package me.steinborn.krypton.mixin.shared.player;
+
+
+import me.steinborn.krypton.mod.shared.player.KryptonServerPlayerEntity;
+import net.minecraft.network.packet.c2s.play.ClientSettingsC2SPacket;
+import net.minecraft.server.network.ServerPlayerEntity;
+import org.spongepowered.asm.mixin.Implements;
+import org.spongepowered.asm.mixin.Interface;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+
+@Mixin(ServerPlayerEntity.class)
+@Implements(@Interface(iface = KryptonServerPlayerEntity.class, prefix = "krypton$", unique = true))
+public class ServerPlayerEntityMixin implements KryptonServerPlayerEntity {
+    @Unique
+    private int playerViewDistance = -1;
+    
+    @Unique
+    private boolean updatedViewDistance = false;
+    
+    @Inject(method = "setClientSettings", at = @At("HEAD"))
+    public void setClientSettings(ClientSettingsC2SPacket packet, CallbackInfo ci) {
+        updatedViewDistance = (playerViewDistance != packet.viewDistance());
+        playerViewDistance = packet.viewDistance();
+    }
+    
+    @Override
+    public boolean isUpdatedViewDistance() {
+        return updatedViewDistance;
+    }
+    
+    @Override
+    public void setUpdatedViewDistance(boolean updatedViewDistance) {
+        this.updatedViewDistance = updatedViewDistance;
+    }
+    
+    @Override
+    public int getPlayerViewDistance() {
+        return playerViewDistance;
+    }
+}

--- a/src/main/java/me/steinborn/krypton/mod/shared/player/KryptonServerPlayerEntity.java
+++ b/src/main/java/me/steinborn/krypton/mod/shared/player/KryptonServerPlayerEntity.java
@@ -3,8 +3,8 @@ package me.steinborn.krypton.mod.shared.player;
 
 public interface KryptonServerPlayerEntity {
     void setUpdatedViewDistance(boolean updatedViewDistance);
-    
+
     int getPlayerViewDistance();
-    
+
     boolean isUpdatedViewDistance();
 }

--- a/src/main/java/me/steinborn/krypton/mod/shared/player/KryptonServerPlayerEntity.java
+++ b/src/main/java/me/steinborn/krypton/mod/shared/player/KryptonServerPlayerEntity.java
@@ -1,0 +1,10 @@
+package me.steinborn.krypton.mod.shared.player;
+
+
+public interface KryptonServerPlayerEntity {
+    void setUpdatedViewDistance(boolean updatedViewDistance);
+    
+    int getPlayerViewDistance();
+    
+    boolean isUpdatedViewDistance();
+}

--- a/src/main/resources/krypton.mixins.json
+++ b/src/main/resources/krypton.mixins.json
@@ -1,31 +1,32 @@
 {
-  "required": true,
-  "minVersion": "0.8",
-  "package": "me.steinborn.krypton.mixin",
-  "compatibilityLevel": "JAVA_16",
-  "plugin": "me.steinborn.krypton.mod.shared.KryptonMixinPlugin",
-  "client": [
-    "client.fastchunkentityaccess.ClientWorldMixin"
-  ],
-  "mixins": [
-    "server.fastchunkentityaccess.ServerWorldMixin",
-    "shared.bugfix.CustomPayloadS2CPacketFixMemoryLeakMixin",
-    "shared.debugaid.ResourceLeakDetectorDisableConditionalMixin",
-    "shared.fastchunkentityaccess.EntityTrackingSectionAccessor",
-    "shared.fastchunkentityaccess.SectionedEntityCacheMixin",
-    "shared.network.avoidwork.ThreadedAnvilChunkStorageMixin",
-    "shared.network.flushconsolidation.ClientConnectionMixin",
-    "shared.network.flushconsolidation.EntityTrackerEntryMixin",
-    "shared.network.flushconsolidation.ThreadedAnvilChunkStorageMixin",
-    "shared.network.microopt.EntityTrackerEntryMixin",
-    "shared.network.microopt.PacketByteBufMixin",
-    "shared.network.pipeline.LegacyQueryHandlerMixin",
-    "shared.network.pipeline.SplitterHandlerMixin",
-    "shared.network.pipeline.compression.ClientConnectionMixin",
-    "shared.network.pipeline.encryption.ClientConnectionMixin",
-    "shared.network.pipeline.encryption.ServerLoginNetworkHandlerMixin"
-  ],
-  "injectors": {
-    "defaultRequire": 1
-  }
+    "required":           true,
+    "minVersion":         "0.8",
+    "package":            "me.steinborn.krypton.mixin",
+    "compatibilityLevel": "JAVA_16",
+    "plugin":             "me.steinborn.krypton.mod.shared.KryptonMixinPlugin",
+    "client":             [
+        "client.fastchunkentityaccess.ClientWorldMixin"
+    ],
+    "mixins":             [
+        "server.fastchunkentityaccess.ServerWorldMixin",
+        "shared.bugfix.CustomPayloadS2CPacketFixMemoryLeakMixin",
+        "shared.debugaid.ResourceLeakDetectorDisableConditionalMixin",
+        "shared.fastchunkentityaccess.EntityTrackingSectionAccessor",
+        "shared.fastchunkentityaccess.SectionedEntityCacheMixin",
+        "shared.network.avoidwork.ThreadedAnvilChunkStorageMixin",
+        "shared.network.flushconsolidation.ClientConnectionMixin",
+        "shared.network.flushconsolidation.EntityTrackerEntryMixin",
+        "shared.network.flushconsolidation.ThreadedAnvilChunkStorageMixin",
+        "shared.network.microopt.EntityTrackerEntryMixin",
+        "shared.network.microopt.PacketByteBufMixin",
+        "shared.network.pipeline.LegacyQueryHandlerMixin",
+        "shared.network.pipeline.SplitterHandlerMixin",
+        "shared.network.pipeline.compression.ClientConnectionMixin",
+        "shared.network.pipeline.encryption.ClientConnectionMixin",
+        "shared.network.pipeline.encryption.ServerLoginNetworkHandlerMixin",
+        "shared.player.ServerPlayerEntityMixin"
+    ],
+    "injectors":          {
+        "defaultRequire": 1
+    }
 }

--- a/src/main/resources/krypton.mixins.json
+++ b/src/main/resources/krypton.mixins.json
@@ -9,6 +9,7 @@
     ],
     "mixins":             [
         "server.fastchunkentityaccess.ServerWorldMixin",
+        "shared.bugfix.ChunkTicketManagerMixin",
         "shared.bugfix.CustomPayloadS2CPacketFixMemoryLeakMixin",
         "shared.debugaid.ResourceLeakDetectorDisableConditionalMixin",
         "shared.fastchunkentityaccess.EntityTrackingSectionAccessor",


### PR DESCRIPTION
Possibly fixes #73

Changes:
- Load chunks in spiral (properly this time)
- Fix nullptr in `ChunkTicketManager`
- Only send chunks within the player's render distance to the client (why doesn't the default client do this. bruh.)