### PR TITLE
Update to 1.19.4

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,9 +2,9 @@
 org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=1.19.1
-yarn_mappings=1.19.1+build.4
-loader_version=0.14.8
+minecraft_version=23w03a
+yarn_mappings=23w03a+build.7
+loader_version=0.14.13
 # Runtime
 lazydfu_version=0.1.3
 # Mod Properties

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,11 +2,9 @@
 org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=23w03a
-yarn_mappings=23w03a+build.7
-loader_version=0.14.13
-# Runtime
-lazydfu_version=0.1.3
+minecraft_version=1.19.4
+yarn_mappings=1.19.4+build.1
+loader_version=0.14.17
 # Mod Properties
 mod_version=0.2.1
 maven_group=me.steinborn

--- a/src/main/java/me/steinborn/krypton/mixin/shared/network/avoidwork/ThreadedAnvilChunkStorageMixin.java
+++ b/src/main/java/me/steinborn/krypton/mixin/shared/network/avoidwork/ThreadedAnvilChunkStorageMixin.java
@@ -5,7 +5,6 @@ import it.unimi.dsi.fastutil.ints.Int2ObjectMaps;
 import me.steinborn.krypton.mod.shared.WorldEntityByChunkAccess;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.mob.MobEntity;
-import net.minecraft.network.Packet;
 import net.minecraft.network.packet.s2c.play.ChunkDataS2CPacket;
 import net.minecraft.network.packet.s2c.play.EntityAttachS2CPacket;
 import net.minecraft.network.packet.s2c.play.EntityPassengersSetS2CPacket;

--- a/src/main/java/me/steinborn/krypton/mixin/shared/network/util/ServerPlayNetworkHandlerAccessor.java
+++ b/src/main/java/me/steinborn/krypton/mixin/shared/network/util/ServerPlayNetworkHandlerAccessor.java
@@ -1,0 +1,13 @@
+package me.steinborn.krypton.mixin.shared.network.util;
+
+import net.minecraft.network.ClientConnection;
+import net.minecraft.server.network.ServerPlayNetworkHandler;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(ServerPlayNetworkHandler.class)
+public interface ServerPlayNetworkHandlerAccessor {
+
+    @Accessor
+    ClientConnection getConnection();
+}

--- a/src/main/java/me/steinborn/krypton/mod/shared/network/util/AutoFlushUtil.java
+++ b/src/main/java/me/steinborn/krypton/mod/shared/network/util/AutoFlushUtil.java
@@ -1,5 +1,6 @@
 package me.steinborn.krypton.mod.shared.network.util;
 
+import me.steinborn.krypton.mixin.shared.network.util.ServerPlayNetworkHandlerAccessor;
 import me.steinborn.krypton.mod.shared.network.ConfigurableAutoFlush;
 import net.minecraft.network.ClientConnection;
 import net.minecraft.server.network.ServerPlayerEntity;
@@ -7,7 +8,7 @@ import net.minecraft.server.network.ServerPlayerEntity;
 public class AutoFlushUtil {
     public static void setAutoFlush(ServerPlayerEntity player, boolean val) {
         if (player.getClass() == ServerPlayerEntity.class) {
-            ConfigurableAutoFlush configurableAutoFlusher = ((ConfigurableAutoFlush) player.networkHandler.getConnection());
+            ConfigurableAutoFlush configurableAutoFlusher = ((ConfigurableAutoFlush) ((ServerPlayNetworkHandlerAccessor) player.networkHandler).getConnection());
             configurableAutoFlusher.setShouldAutoFlush(val);
         }
     }

--- a/src/main/resources/krypton.mixins.json
+++ b/src/main/resources/krypton.mixins.json
@@ -24,6 +24,7 @@
         "shared.network.pipeline.compression.ClientConnectionMixin",
         "shared.network.pipeline.encryption.ClientConnectionMixin",
         "shared.network.pipeline.encryption.ServerLoginNetworkHandlerMixin",
+        "shared.network.util.ServerPlayNetworkHandlerAccessor",
         "shared.player.ServerPlayerEntityMixin"
     ],
     "injectors":          {


### PR DESCRIPTION
A simple update to 1.19.4
The visibility of `ServerPlayNetworkHandler.connection` was changed from public to private, which requires a mixin accessor now.