### PR TITLE
Fixed NoSuchElementException if threshold is negative

### DIFF
--- a/src/main/java/me/steinborn/krypton/mixin/shared/network/pipeline/compression/ClientConnectionMixin.java
+++ b/src/main/java/me/steinborn/krypton/mixin/shared/network/pipeline/compression/ClientConnectionMixin.java
@@ -6,6 +6,8 @@ import io.netty.channel.Channel;
 import me.steinborn.krypton.mod.shared.network.compression.MinecraftCompressDecoder;
 import me.steinborn.krypton.mod.shared.network.compression.MinecraftCompressEncoder;
 import net.minecraft.network.ClientConnection;
+import net.minecraft.network.PacketDeflater;
+import net.minecraft.network.PacketInflater;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;

--- a/src/main/java/me/steinborn/krypton/mixin/shared/network/pipeline/compression/ClientConnectionMixin.java
+++ b/src/main/java/me/steinborn/krypton/mixin/shared/network/pipeline/compression/ClientConnectionMixin.java
@@ -37,9 +37,13 @@ public class ClientConnectionMixin {
 
     @Inject(method = "setCompressionThreshold", at = @At("HEAD"), cancellable = true)
     public void setCompressionThreshold(int compressionThreshold, boolean validate, CallbackInfo ci) {
-        if (compressionThreshold == -1) {
-            this.channel.pipeline().remove("decompress");
-            this.channel.pipeline().remove("compress");
+        if (compressionThreshold < 0) {
+            if (this.channel.pipeline().get("decompress") instanceof PacketInflater) {
+                this.channel.pipeline().remove("decompress");
+            }
+            if (this.channel.pipeline().get("compress") instanceof PacketDeflater) {
+                this.channel.pipeline().remove("compress");
+            }
         } else {
             MinecraftCompressDecoder decoder = (MinecraftCompressDecoder) channel.pipeline()
                     .get("decompress");

--- a/src/main/java/me/steinborn/krypton/mixin/shared/network/pipeline/compression/ClientConnectionMixin.java
+++ b/src/main/java/me/steinborn/krypton/mixin/shared/network/pipeline/compression/ClientConnectionMixin.java
@@ -6,8 +6,6 @@ import io.netty.channel.Channel;
 import me.steinborn.krypton.mod.shared.network.compression.MinecraftCompressDecoder;
 import me.steinborn.krypton.mod.shared.network.compression.MinecraftCompressEncoder;
 import net.minecraft.network.ClientConnection;
-import net.minecraft.network.PacketDeflater;
-import net.minecraft.network.PacketInflater;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -40,10 +38,10 @@ public class ClientConnectionMixin {
     @Inject(method = "setCompressionThreshold", at = @At("HEAD"), cancellable = true)
     public void setCompressionThreshold(int compressionThreshold, boolean validate, CallbackInfo ci) {
         if (compressionThreshold < 0) {
-            if (this.channel.pipeline().get("decompress") instanceof PacketInflater) {
+            if (this.channel.pipeline().get("decompress") != null) {
                 this.channel.pipeline().remove("decompress");
             }
-            if (this.channel.pipeline().get("compress") instanceof PacketDeflater) {
+            if (this.channel.pipeline().get("compress") != null) {
                 this.channel.pipeline().remove("compress");
             }
         } else {


### PR DESCRIPTION
This PullRequest fixes a NoSuchElementException if the server sends a negative threshold in the compression, you can test it yourself:
1. start Krypton
2. join "raphimc.net".

Without my fix you will be kicked for a NoSuchElementException.