### PR TITLE
Resolve mixin conflict between Krypton and e4mc

### DIFF
--- a/src/main/java/me/steinborn/krypton/mod/shared/KryptonMixinPlugin.java
+++ b/src/main/java/me/steinborn/krypton/mod/shared/KryptonMixinPlugin.java
@@ -8,6 +8,8 @@ import java.util.List;
 import java.util.Set;
 
 public class KryptonMixinPlugin implements IMixinConfigPlugin {
+    private static final boolean E4MC_LOADED = FabricLoader.getInstance().isModLoaded("e4mc");
+
     @Override
     public void onLoad(String mixinPackage) {
 
@@ -20,6 +22,11 @@ public class KryptonMixinPlugin implements IMixinConfigPlugin {
 
     @Override
     public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
+        // Disable ServerLoginNetworkHandlerMixin if e4mc is loaded, as it conflicts with e4mc's
+        // encryption handling for Dialtone (P2P) connections
+        if (E4MC_LOADED && mixinClassName.equals("me.steinborn.krypton.mixin.shared.network.pipeline.encryption.ServerLoginNetworkHandlerMixin")) {
+            return false;
+        }
         return true;
     }
 


### PR DESCRIPTION
Resolves mixin conflict between Krypton and e4mc by disabling ServerLoginNetworkHandlerMixin when e4mc is present. Both mods redirect the same method during encryption setup, causing conflicts.
Fixes #152 
