### PR TITLE
Add GitHub Actions workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,38 @@
+# Automatically build the project and run any configured tests for every push
+# and submitted pull request. This can help catch issues that only occur on
+# certain platforms or Java versions, and provides a first line of defence
+# against bad commits.
+
+name: build
+on: [ pull_request, push ]
+
+jobs:
+  build:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v6
+
+      - name: setup jdk
+        uses: actions/setup-java@v5
+        with:
+          java-version: '25'
+          distribution: 'microsoft'
+
+      - name: setup gradle
+        uses: gradle/actions/setup-gradle@v5
+
+      - name: build
+        run: ./gradlew build
+
+      - name: capture build artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          archive: false
+          path: |
+            build/libs/*.jar
+            !build/libs/*-dev.jar
+            !build/libs/*-sources.jar
+            !build/libs/*-javadoc.jar

--- a/README.md
+++ b/README.md
@@ -22,6 +22,6 @@ answer your question.
 
 Releases I deem reasonably stable can be found on [GitHub](https://github.com/astei/krypton/releases),
 [CurseForge](https://www.curseforge.com/minecraft/mc-mods/krypton), and on [Modrinth](https://modrinth.com/mod/krypton).
-Development builds may be downloaded from my [Jenkins server](https://ci.velocitypowered.com/job/krypton/).
+Development builds may be downloaded from [GitHub Actions](https://github.com/astei/krypton/actions).
 
 You can also compile the mod from source in the usual fashion.


### PR DESCRIPTION
Mostly same as the Fabric example mod template workflow, except uses newer versions of actions, uses setup-gradle instead of wrapper-validation for cache plus wrapper-validation, and uploads the main artifact as a single file (new feature in upload-artifact v7 where it doesn't have to .zip anymore) - sources/javadoc/dev jars are not uploaded. Microsoft JDK is used to keep it close to the fabric template and the runtime expectations, but Temurin or any other would also work.

Related #158 (Feel free to close this PR if the link was redirecting wrongfully and the Jenkins is still up)