### PR TITLE
fix #118 and #128

### DIFF
--- a/src/main/java/me/steinborn/krypton/mixin/shared/network/pipeline/Varint21FrameDecoderMixin.java
+++ b/src/main/java/me/steinborn/krypton/mixin/shared/network/pipeline/Varint21FrameDecoderMixin.java
@@ -3,9 +3,13 @@ package me.steinborn.krypton.mixin.shared.network.pipeline;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import me.steinborn.krypton.mod.shared.network.util.QuietDecoderException;
+import me.steinborn.krypton.mod.shared.network.util.VarIntUtil;
+import net.minecraft.network.BandwidthDebugMonitor;
 import net.minecraft.network.Varint21FrameDecoder;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 
 import java.util.List;
@@ -20,6 +24,10 @@ import static me.steinborn.krypton.mod.shared.network.util.WellKnownExceptions.V
  */
 @Mixin(Varint21FrameDecoder.class)
 public class Varint21FrameDecoderMixin {
+
+    @Final @Shadow
+    private BandwidthDebugMonitor monitor;
+
     /**
      * @author Andrew Steinborn
      * @reason Use optimized Velocity varint decoder that reduces bounds checking
@@ -55,6 +63,9 @@ public class Varint21FrameDecoderMixin {
             if (in.readableBytes() < length) {
                 in.resetReaderIndex();
             } else {
+                if (this.monitor != null) {
+                    this.monitor.onReceive(length + VarIntUtil.getVarIntLength(length));
+                }
                 out.add(in.readRetainedSlice(length));
             }
         }


### PR DESCRIPTION
This is a very minor change that I've been using for a long time, and I've decided to merge it back upstream

### Screenshots

<details>
<summary><b>Before</b></summary>
<img width="2559" height="1367" alt="image" src="https://github.com/user-attachments/assets/c5b46013-e85e-4979-9f02-95f9ec0e0b17" />
</details>

<details>
<summary><b>After</b></summary>
<img width="2559" height="1361" alt="image" src="https://github.com/user-attachments/assets/f04b246f-e903-4a25-ac0a-5c7587076c9b" />

The BandwidthDebugMonitor component in the bottom left corner is now working correctly.
</details>

close #118 and close #128 
