### PR TITLE
Refactor ServerLogin encryption injection to use @WrapOperation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,8 @@ dependencies {
     minecraft "com.mojang:minecraft:${project.minecraft_version}"
     implementation "net.fabricmc:fabric-loader:${project.loader_version}"
     implementation include("com.velocitypowered:velocity-native:3.4.0-SNAPSHOT")
+    implementation include("io.github.llamalad7:mixinextras-fabric:0.4.1")
+    annotationProcessor "io.github.llamalad7:mixinextras-fabric:0.4.1"
 }
 
 test {

--- a/src/main/java/me/steinborn/krypton/mixin/shared/network/pipeline/encryption/ConnectionMixin.java
+++ b/src/main/java/me/steinborn/krypton/mixin/shared/network/pipeline/encryption/ConnectionMixin.java
@@ -11,7 +11,11 @@ import net.minecraft.network.Connection;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
 import java.security.GeneralSecurityException;
 
@@ -35,5 +39,12 @@ public class ConnectionMixin implements ClientConnectionEncryptionExtension {
         this.channel.pipeline().fireUserEventTriggered(KryptonPipelineEvent.ENCRYPTION_ENABLED);
 
         this.kryptonEncryptionEnabled = true;
+    }
+
+    @Inject(method = "setEncryptionKey", at = @At("HEAD"), cancellable = true)
+    private void cancelVanillaEncryptionIfKryptonEnabled(Cipher decryptCipher, Cipher encryptCipher, CallbackInfo ci) {
+        if (this.kryptonEncryptionEnabled) {
+            ci.cancel();
+        }
     }
 }

--- a/src/main/java/me/steinborn/krypton/mixin/shared/network/pipeline/encryption/ServerLoginPacketListenerImplMixin.java
+++ b/src/main/java/me/steinborn/krypton/mixin/shared/network/pipeline/encryption/ServerLoginPacketListenerImplMixin.java
@@ -1,5 +1,8 @@
 package me.steinborn.krypton.mixin.shared.network.pipeline.encryption;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Local;
 import me.steinborn.krypton.mod.shared.network.ClientConnectionEncryptionExtension;
 import net.minecraft.network.Connection;
 import net.minecraft.server.network.ServerLoginPacketListenerImpl;
@@ -7,28 +10,20 @@ import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
 
 import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
 import java.security.GeneralSecurityException;
-import java.security.Key;
 
 @Mixin(ServerLoginPacketListenerImpl.class)
 public class ServerLoginPacketListenerImplMixin {
     @Shadow @Final Connection connection;
 
-    @Redirect(method = "handleKey", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/Crypt;getCipher(ILjava/security/Key;)Ljavax/crypto/Cipher;"))
-    private Cipher onKey$initializeVelocityCipher(int ignored1, Key secretKey) throws GeneralSecurityException {
-        // Hijack this portion of the cipher initialization and set up our own encryption handler.
-        ((ClientConnectionEncryptionExtension) this.connection).setupEncryption((SecretKey) secretKey);
-
-        // Turn the operation into a no-op.
-        return null;
-    }
-
-    @Redirect(method = "handleKey", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/Connection;setEncryptionKey(Ljavax/crypto/Cipher;Ljavax/crypto/Cipher;)V"))
-    public void onKey$ignoreMinecraftEncryptionPipelineInjection(Connection connection, Cipher ignored1, Cipher ignored2) {
-        // Turn the operation into a no-op.
+    @WrapOperation(method = "handleKey", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/Connection;setEncryptionKey(Ljavax/crypto/Cipher;Ljavax/crypto/Cipher;)V"))
+    private void onKey$setupEncryption(Connection instance, Cipher decryptCipher, Cipher encryptCipher, Operation<Void> original, @Local SecretKey secretKey) throws GeneralSecurityException {
+        if (secretKey != null) {
+            ((ClientConnectionEncryptionExtension) instance).setupEncryption(secretKey);
+        }
+        original.call(instance, decryptCipher, encryptCipher);
     }
 }


### PR DESCRIPTION
Hey

This PR refactors `ServerLoginPacketListenerImplMixin` to replace the old `@Redirect`s with MixinExtras `@WrapOperation` and a standard cancellable `@Inject`.

Unlike PR #153 , this doesn't use any `isModLoaded` hacks or disable native ciphers. Velocity native encryption stays fully active and running as usual on all standard connections, but switching away from `@Redirect` stops Mixin from crashing when other network mods touch `handleKey`.

Tested on integrated server and LAN, everything connects, and native ciphers work properly.

Fixes #152 